### PR TITLE
Support arbitrary output format based on language

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ rounding error on your startup time.
 
 ## Configuration
 
-### Simple configuration
-
 The simplest configuration only requires you to decide what plain text
 representation you want jupytext to output. The default configuration is:
 
@@ -46,34 +44,32 @@ If you need something different pass your own configuration to
 
 ```lua
 require("jupytext").setup({ style = "light" })
-
 ```
 
-### Configuration for Quarto users
+> [!TIP]
+> Quarto format users keep on reading!
 
 By default we use the `auto` mode of jupytext. This will create a script with
-the correct extension for each language. However, users of Quarto will want to
-convert the files to Quarto markdown with file extension `qmd`.  The use of the
-`auto` mode can be overriden in a per language basis by explicitly declaring
-what file extension, jupytext style and Neovim filetype you want. For example,
-to use the Quarto file extension and jupytext style with Python you could add
-the following to your configuration.
+the correct extension for each language. However, this can be overriden in a
+per language basis if you want to. For this add to the configuration options an
+field named `custom_language_formatting` which contains a series of per
+language fields. For example:
 
 ```lua
-{
-  custom_language_formatting = {
-    python = {
-      extension = "qmd",
-      style = "quarto",
-      force_ft = "quarto",
-    },
+custom_language_formatting = {
+  python = {
+    extension = "qmd",
+    style = "quarto",
+    force_ft = true,
   },
-},
+}
 ```
 
-The `force_ft` option is there to allow you what filetype you want the buffer
-to be set to. This is important to get other plugins like
-[otter.nvim](https://github.com//otter.nvim) working correctly.
+If `force_ft` is `true` AND the style is `quarto` the filetype for the buffer
+will be set to quarto regardless of the language.  This is important to get
+other plugins like [otter.nvim](https://github.com/jmbuhr/otter.nvim) working
+correctly.
+
 
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ rounding error on your startup time.
 
 ## Configuration
 
-The only configuration parameter available is the jupytext style you want to
-use for the plain text version of the files. The default configuration is:
+### Simple configuration
+
+The simplest configuration only requires you to decide what plain text
+representation you want jupytext to output. The default configuration is:
 
 ```lua
 {
@@ -44,7 +46,35 @@ If you need something different pass your own configuration to
 
 ```lua
 require("jupytext").setup({ style = "light" })
+
 ```
+
+### Configuration for Quarto users
+
+By default we use the `auto` mode of jupytext. This will create a script with
+the correct extension for each language. However, users of Quarto will want to
+convert the files to Quarto markdown with file extension `qmd`.  The use of the
+`auto` mode can be overriden in a per language basis by explicitly declaring
+what file extension, jupytext style and Neovim filetype you want. For example,
+to use the Quarto file extension and jupytext style with Python you could add
+the following to your configuration.
+
+```lua
+{
+  custom_language_formatting = {
+    python = {
+      extension = "qmd",
+      style = "quarto",
+      force_ft = "quarto",
+    },
+  },
+},
+```
+
+The `force_ft` option is there to allow you what filetype you want the buffer
+to be set to. This is important to get other plugins like
+[otter.nvim](https://github.com//otter.nvim) working correctly.
+
 
 ## Acknowledgements
 This plugin is a lua port of [goerz/jupytext.vim](https://www.github.com/goerz/jupytext.vim) and it wouldn't have existed without it.

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -19,6 +19,7 @@ local write_to_ipynb = function(ipynb_filename, output_extension)
     ["--to"] = "ipynb",
     ["--output"] = vim.fn.shellescape(ipynb_filename),
   })
+  vim.api.nvim_buf_set_option(0, 'modified', false)
 end
 
 local cleanup = function(jupytext_filename, delete)

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -91,13 +91,15 @@ local read_from_ipynb = function(ipynb_filename)
   })
 
   local ft = nil
-  if custom_formatting then
-    if custom_formatting.force_ft then
-      ft = metadata.language
+  if custom_formatting ~= nil then
+    if custom_formatting.force_ft ~= nil then
+      print(custom_formatting.force_ft)
+      ft = custom_formatting.force_ft
     end
   end
+
   if not ft then
-    ft = output_extension
+    ft = metadata.language
   end
 
   vim.api.nvim_command("setlocal fenc=utf-8 ft=" .. ft)

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -19,7 +19,7 @@ local write_to_ipynb = function(ipynb_filename, output_extension)
     ["--to"] = "ipynb",
     ["--output"] = vim.fn.shellescape(ipynb_filename),
   })
-  vim.api.nvim_buf_set_option(0, 'modified', false)
+  vim.api.nvim_buf_set_option(0, "modified", false)
 end
 
 local cleanup = function(jupytext_filename, delete)
@@ -93,9 +93,10 @@ local read_from_ipynb = function(ipynb_filename)
 
   local ft = nil
   if custom_formatting ~= nil then
-    if custom_formatting.force_ft ~= nil then
-      print(custom_formatting.force_ft)
-      ft = custom_formatting.force_ft
+    if custom_formatting.force_ft then
+      if custom_formatting.style == "quarto" then
+        ft = "quarto"
+      end
     end
   end
 

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -34,10 +34,15 @@ local read_from_ipynb = function(ipynb_filename)
   -- Decide output extension and style
   local to_extension_and_style
   local output_extension
+
+  local custom_formatting = nil
   if utils.check_key(M.config.custom_language_formatting, metadata.language) then
-    local formatting = M.config.custom_language_formatting[metadata.language]
-    output_extension = formatting.extension
-    to_extension_and_style = output_extension .. ":" .. formatting.style
+    custom_formatting = M.config.custom_language_formatting[metadata.language]
+  end
+
+  if custom_formatting then
+    output_extension = custom_formatting.extension
+    to_extension_and_style = output_extension .. ":" .. custom_formatting.style
   else
     to_extension_and_style = "auto" .. ":" .. M.config.style
     output_extension = metadata.extension
@@ -85,7 +90,17 @@ local read_from_ipynb = function(ipynb_filename)
     end,
   })
 
-  vim.api.nvim_command("setlocal fenc=utf-8 ft=" .. output_extension)
+  local ft = nil
+  if custom_formatting then
+    if custom_formatting.force_ft then
+      ft = metadata.language
+    end
+  end
+  if not ft then
+    ft = output_extension
+  end
+
+  vim.api.nvim_command("setlocal fenc=utf-8 ft=" .. ft)
 
   -- In order to make :undo a no-op immediately after the buffer is read, we
   -- need to do this dance with 'undolevels'.  Actually discarding the undo

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -9,7 +9,6 @@ M.config = {
 }
 
 local write_to_ipynb = function(ipynb_filename, output_extension)
-  local metadata = utils.get_ipynb_metadata(ipynb_filename)
   local jupytext_filename = utils.get_jupytext_file(ipynb_filename, output_extension)
   jupytext_filename = vim.fn.resolve(vim.fn.expand(jupytext_filename))
 
@@ -65,8 +64,12 @@ local read_from_ipynb = function(ipynb_filename)
   if vim.fn.filereadable(jupytext_filename) then
     local jupytext_content = vim.fn.readfile(jupytext_filename)
 
+    -- Need to add an extra line so that the undo dance that comes later on
+    -- doesn't delete the first line of the actual input
+    table.insert(jupytext_content, 1, "")
+
     -- Replace the buffer content with the jupytext content
-    vim.fn.setline(1, jupytext_content)
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, jupytext_content)
   else
     error "Couldn't find jupytext file."
     return

--- a/lua/jupytext/utils.lua
+++ b/lua/jupytext/utils.lua
@@ -21,4 +21,14 @@ M.get_jupytext_file = function(filename, extension)
   return fileroot .. extension
 end
 
+M.check_key = function(tbl, key)
+  for tbl_key, _ in pairs(tbl) do
+    if tbl_key == key then
+      return true
+    end
+  end
+
+  return false
+end
+
 return M

--- a/lua/jupytext/utils.lua
+++ b/lua/jupytext/utils.lua
@@ -1,11 +1,11 @@
 local M = {}
 
 local language_extensions = {
-  python = ".py",
-  julia = ".jl",
-  r = ".r",
-  R = ".r",
-  bash = ".sh",
+  python = "py",
+  julia = "jl",
+  r = "r",
+  R = "r",
+  bash = "sh",
 }
 
 M.get_ipynb_metadata = function(filename)
@@ -18,7 +18,7 @@ end
 
 M.get_jupytext_file = function(filename, extension)
   local fileroot = vim.fn.fnamemodify(filename, ":r")
-  return fileroot .. extension
+  return fileroot .. "." .. extension
 end
 
 M.check_key = function(tbl, key)


### PR DESCRIPTION
Addresses #1 

A new config option `custom_language_formatting` has been added. It's a table with keys being language names and values being a table such as `{extension="md", style="myst"}`.

If a spec for the language defined in the notebook metadata is available it will override the `auto` mode.

The only caveat is that the filetype of the buffer will be set to the extension. This implies, that unless the rest of the user's configuration is build to support a "language non-native file extension" [*] workflow, some features, such as the language LSP, will not be available.

[*] Could not find a better way to describe this

