### PR TITLE
fixed bug related to the cleanup of files after the buffer is destroyed

### DIFF
--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -20,9 +20,11 @@ local write_to_ipynb = function(ipynb_filename)
   })
 end
 
-local cleanup = function(jupytext_filename, delete)
+local cleanup = function(ipynb_filename, delete)
+  local metadata = utils.get_ipynb_metadata(ipynb_filename)
+  local jupytext_filename = utils.get_jupytext_file(ipynb_filename, metadata.extension)
   if delete then
-    vim.cmd.delete(vim.fn.resolve(vim.fn.expand(jupytext_filename)))
+    vim.fn.delete(vim.fn.resolve(vim.fn.expand(jupytext_filename)))
   end
 end
 


### PR DESCRIPTION
Hi, please forgive me if I misunderstood something, but to my understanding, the purpose of the function `cleanup` is to remove the temporary files that are used to replace the buffer.  For instance, with `.ipynb` files, an additional `.py` file is generated and replace the buffer that would contain the `.ipynb` file.

I am on version 0.9.4 of nvim and I find that this cleanup function throws an error stating that "the delete function does not have enough arguments".  After doing some research, I have identified the culprit and found a bug that the cleanup function where the cleanup function actually deletes the `.ipynb` file instead of the temporary `.py` file generated.