### PR TITLE
allow arbitrary force_ft

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,29 +47,38 @@ require("jupytext").setup({ style = "light" })
 ```
 
 > [!TIP]
-> Quarto format users keep on reading!
+> Quarto and markdown format users keep on reading!
 
 By default we use the `auto` mode of jupytext. This will create a script with
-the correct extension for each language. However, this can be overriden in a
-per language basis if you want to. For this add to the configuration options an
+the correct extension for each language. However, this can be overridden in a
+per language basis if you want to. For this add to the configuration options a
 field named `custom_language_formatting` which contains a series of per
-language fields. For example:
+language fields. For example, to convert python files to quarto markdown:
 
 ```lua
 custom_language_formatting = {
   python = {
     extension = "qmd",
     style = "quarto",
-    force_ft = true,
+    force_ft = "quarto", -- you can set whatever filetype you want here
   },
 }
 ```
 
-If `force_ft` is `true` AND the style is `quarto` the filetype for the buffer
-will be set to quarto regardless of the language.  This is important to get
-other plugins like [otter.nvim](https://github.com/jmbuhr/otter.nvim) working
-correctly.
+Or, for regular markdown:
 
+```lua
+custom_language_formatting = {
+  python = {
+    extension = "md",
+    style = "markdown",
+    force_ft = "markdown", -- you can set whatever filetype you want here
+  },
+}
+```
+
+Setting force_ft is important to get other plugins like
+[otter.nvim](https://github.com/jmbuhr/otter.nvim) working correctly.
 
 
 ## Acknowledgements

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -18,7 +18,8 @@ local write_to_ipynb = function(ipynb_filename, output_extension)
     ["--to"] = "ipynb",
     ["--output"] = vim.fn.shellescape(ipynb_filename),
   })
-  vim.api.nvim_buf_set_option(0, "modified", false)
+  local buf = vim.api.nvim_get_current_buf()
+  vim.api.nvim_set_option_value("modified", false, { scope = "local", buf = buf })
 end
 
 local cleanup = function(ipynb_filename, delete)
@@ -101,6 +102,9 @@ local read_from_ipynb = function(ipynb_filename)
     if custom_formatting.force_ft then
       if custom_formatting.style == "quarto" then
         ft = "quarto"
+      else
+        -- just let the user set whatever ft they want
+        ft = custom_formatting.force_ft
       end
     end
   end

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -19,7 +19,7 @@ local write_to_ipynb = function(ipynb_filename, output_extension)
     ["--output"] = vim.fn.shellescape(ipynb_filename),
   })
   local buf = vim.api.nvim_get_current_buf()
-  vim.api.nvim_set_option_value("modified", false, { scope = "local", buf = buf })
+  vim.api.nvim_set_option_value("modified", false, { buf = buf })
 end
 
 local cleanup = function(ipynb_filename, delete)


### PR DESCRIPTION
closes #4

Changes the way `force_ft` works so that it accepts a string, and will set the filetype to the given string value. Keeps the logic in place so that setting it to true while the style is `quarto` will set the filetype to quarto.

This allows for configuration that mimics `jupytext.vim` which creates a regular markdown file.
