### PR TITLE
fix: fire post write auto command after writing

### DIFF
--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -8,7 +8,8 @@ M.config = {
   custom_language_formatting = {},
 }
 
-local write_to_ipynb = function(ipynb_filename, output_extension)
+local write_to_ipynb = function(event, output_extension)
+  local ipynb_filename = event.match
   local jupytext_filename = utils.get_jupytext_file(ipynb_filename, output_extension)
   jupytext_filename = vim.fn.resolve(vim.fn.expand(jupytext_filename))
 
@@ -20,6 +21,12 @@ local write_to_ipynb = function(ipynb_filename, output_extension)
   })
   local buf = vim.api.nvim_get_current_buf()
   vim.api.nvim_set_option_value("modified", false, { buf = buf })
+
+  local post_write = "BufWritePost"
+  if event.event == "FileWriteCmd" then
+    post_write = "FileWritePost"
+  end
+  vim.api.nvim_exec_autocmds(post_write, { pattern = ipynb_filename })
 end
 
 local cleanup = function(ipynb_filename, delete)
@@ -93,7 +100,7 @@ local read_from_ipynb = function(ipynb_filename)
     pattern = "<buffer>",
     group = "jupytext-nvim",
     callback = function(ev)
-      write_to_ipynb(ev.match, output_extension)
+      write_to_ipynb(ev, output_extension)
     end,
   })
 

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -31,23 +31,9 @@ end
 
 local cleanup = function(ipynb_filename, delete)
   local metadata = utils.get_ipynb_metadata(ipynb_filename)
-
-  local custom_formatting = nil
-  if utils.check_key(M.config.custom_language_formatting, metadata.language) then
-    custom_formatting = M.config.custom_language_formatting[metadata.language]
-  end
-
-  local output_extension = nil
-
-  if custom_formatting then
-    output_extension = custom_formatting.extension
-  else
-    output_extension = metadata.extension
-  end
-
-  local jupytext_filename = utils.get_jupytext_file(ipynb_filename, output_extension)
+  local jupytext_filename = utils.get_jupytext_file(ipynb_filename, metadata.extension)
   if delete then
-    vim.fn.delete(P(vim.fn.resolve(vim.fn.expand(jupytext_filename))))
+    vim.fn.delete(vim.fn.resolve(vim.fn.expand(jupytext_filename)))
   end
 end
 

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -31,9 +31,23 @@ end
 
 local cleanup = function(ipynb_filename, delete)
   local metadata = utils.get_ipynb_metadata(ipynb_filename)
-  local jupytext_filename = utils.get_jupytext_file(ipynb_filename, metadata.extension)
+
+  local custom_formatting = nil
+  if utils.check_key(M.config.custom_language_formatting, metadata.language) then
+    custom_formatting = M.config.custom_language_formatting[metadata.language]
+  end
+
+  local output_extension = nil
+
+  if custom_formatting then
+    output_extension = custom_formatting.extension
+  else
+    output_extension = metadata.extension
+  end
+
+  local jupytext_filename = utils.get_jupytext_file(ipynb_filename, output_extension)
   if delete then
-    vim.fn.delete(vim.fn.resolve(vim.fn.expand(jupytext_filename)))
+    vim.fn.delete(P(vim.fn.resolve(vim.fn.expand(jupytext_filename))))
   end
 end
 


### PR DESCRIPTION
closes #8

Fires the correct autocmd (either `BufWritePost` or `FileWritePost`) after writing the file
