### PR TITLE
fix: use output_extension when specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ representation you want jupytext to output. The default configuration is:
 ```lua
 {
   style = "hydrogen",
-  extension = "auto",  -- Default extension. Don't change unless you know what you are doing
+  output_extension = "auto",  -- Default extension. Don't change unless you know what you are doing
   force_ft = nil,  -- Default filetype. Don't change unless you know what you are doing
   custom_language_formatting = {},
 }

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -44,7 +44,11 @@ local style_and_extension = function(metadata)
     output_extension = custom_formatting.extension
     to_extension_and_style = output_extension .. ":" .. custom_formatting.style
   else
-    output_extension = metadata.extension
+    if M.config.output_extension == "auto" then
+      output_extension = metadata.extension
+    else
+      output_extension = M.config.output_extension
+    end
     to_extension_and_style = M.config.output_extension .. ":" .. M.config.style
   end
 


### PR DESCRIPTION
The output extension wasn't getting used, and the docs referred to the `extension` field instead of the `output_extension` field that was being used in the code.

Both of those should be fixed in this PR
