### PR TITLE
add fallback metadata langauge lookup

### DIFF
--- a/lua/jupytext/utils.lua
+++ b/lua/jupytext/utils.lua
@@ -8,9 +8,16 @@ local language_extensions = {
   bash = "sh",
 }
 
+local language_names = {
+  python3 = "python",
+}
+
 M.get_ipynb_metadata = function(filename)
   local metadata = vim.json.decode(io.open(filename, "r"):read "a")["metadata"]
   local language = metadata.kernelspec.language
+  if language == nil then
+    language = language_names[metadata.kernelspec.name]
+  end
   local extension = language_extensions[language]
 
   return { language = language, extension = extension }


### PR DESCRIPTION
fixes #17.

the [spec](https://github.com/jupyter/nbformat/blob/main/nbformat/v4/nbformat.v4.0.schema.json) mentions `name` and `display_name` as required. [irkernel docs](https://github.com/IRkernel/IRkernel/tree/1eddb304b246c14b62949abd946e8d4ca5080d25?tab=readme-ov-file) state that the name can vary depending on version so it may require a large dictionary eventually. regardless, I went with `kernelspec.name` as a fallback.