### PR TITLE
fix: correctly infer output extension for jupytext command

### DIFF
--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -49,7 +49,7 @@ local style_and_extension = function(metadata)
     else
       output_extension = M.config.output_extension
     end
-    to_extension_and_style = M.config.output_extension .. ":" .. M.config.style
+    to_extension_and_style = output_extension .. ":" .. M.config.style
   end
 
   return custom_formatting, output_extension, to_extension_and_style


### PR DESCRIPTION
fixes a bug where extracted metadata information is not used when constructing the jupytext command to convert python.
NOTE: this and #19 are both required to fix issues when opening a Google Colab exported notebook.

*Context*
I get the following metadata from a notebook exported directly from Google Colab. jupytext doesn't have enough information to use `auto:hydrogen` when converting:

```json
  "metadata": {
    "colab": {
      "provenance": []
    },
    "kernelspec": {
      "name": "python3",
      "display_name": "Python 3"
    },
    "language_info": {
      "name": "python"
    }
```