### PR TITLE
fix: jypytext not found and update vim health methods

### DIFF
--- a/lua/jupytext/commands.lua
+++ b/lua/jupytext/commands.lua
@@ -1,13 +1,14 @@
 local M = {}
 
 M.run_jupytext_command = function(input_file, options)
-  local cmd = "jupytext " .. input_file .. " "
+  local cmd = { "jupytext", input_file }
   for option_name, option_value in pairs(options) do
     if option_value ~= "" then
-      cmd = cmd .. option_name .. "=" .. option_value .. " "
+      local option = option_name .. "=" .. option_value
+      table.insert(cmd, option)
     else
       -- empty string value implies this options is just a flag
-      cmd = cmd .. option_name .. " "
+      table.insert(cmd, option_name)
     end
   end
 

--- a/lua/jupytext/health.lua
+++ b/lua/jupytext/health.lua
@@ -1,13 +1,13 @@
 local M = {}
 
 M.check = function()
-  vim.health.report_start "jupytext.nvim"
+  vim.health.start "jupytext.nvim"
   vim.fn.system "jupytext --version"
 
   if vim.v.shell_error == 0 then
-    vim.health.report_ok "Jupytext is available"
+    vim.health.ok "Jupytext is available"
   else
-    vim.health.report_error("Jupytext is not available", "Install jupytext via `pip install jupytext`")
+    vim.health.error("Jupytext is not available", "Install jupytext via `pip install jupytext`")
   end
 end
 

--- a/lua/jupytext/health.lua
+++ b/lua/jupytext/health.lua
@@ -2,8 +2,7 @@ local M = {}
 
 M.check = function()
   vim.health.start "jupytext.nvim"
-  vim.fn.system "jupytext --version"
-
+  vim.fn.system({ "jupytext", "--version" })
   if vim.v.shell_error == 0 then
     vim.health.ok "Jupytext is available"
   else


### PR DESCRIPTION
### Fix: `jypytext` not available on macOS Sonoma 14.5

**Problem:**
`jypytext` was not found on macOS Sonoma 14.5 using global package, virtual environment, or Python host via `vim.g`.

**Solution:**
Using a table in `vim.fn.system` instead of a string fixes the issue.

**Changes:**
- Changed string to table in `vim.fn.system`.
- Additionally updated `vim.health` methods.