### PR TITLE
fix: jupytext ignoring python3_host_prog

### DIFF
--- a/lua/jupytext/commands.lua
+++ b/lua/jupytext/commands.lua
@@ -1,7 +1,12 @@
 local M = {}
 
 M.run_jupytext_command = function(input_file, options)
-  local cmd = "jupytext " .. input_file .. " "
+  local cmd = ""
+  if vim.g.python3_host_prog ~= nil then
+    cmd = vim.g.python3_host_prog .. " -m "
+  end
+
+  cmd = cmd .. "jupytext " .. input_file .. " "
   for option_name, option_value in pairs(options) do
     if option_value ~= "" then
       cmd = cmd .. option_name .. "=" .. option_value .. " "

--- a/lua/jupytext/commands.lua
+++ b/lua/jupytext/commands.lua
@@ -2,7 +2,7 @@ local M = {}
 
 M.run_jupytext_command = function(input_file, options)
   local cmd = ""
-  if vim.g.python3_host_prog ~= nil then
+  if vim.g.python3_host_prog ~= nil and vim.fn.executable "jupytext" == 0 then
     cmd = vim.g.python3_host_prog .. " -m "
   end
 

--- a/lua/jupytext/health.lua
+++ b/lua/jupytext/health.lua
@@ -2,7 +2,13 @@ local M = {}
 
 M.check = function()
   vim.health.report_start "jupytext.nvim"
-  vim.fn.system "jupytext --version"
+
+  local cmd = ""
+  if vim.g.python3_host_prog ~= nil and vim.fn.executable "jupytext" == 0 then
+    cmd = vim.g.python3_host_prog .. " -m "
+  end
+
+  vim.fn.system(cmd .. "jupytext --version")
 
   if vim.v.shell_error == 0 then
     vim.health.report_ok "Jupytext is available"


### PR DESCRIPTION
Jupytext will now use the python3_host_prog if it is set
Fixes #24 