### PR TITLE
Fix ShellEscapes + vim.health

### DIFF
--- a/lua/jupytext/commands.lua
+++ b/lua/jupytext/commands.lua
@@ -1,13 +1,14 @@
 local M = {}
 
 M.run_jupytext_command = function(input_file, options)
-  local cmd = "jupytext " .. input_file .. " "
+  local cmd = { "jupytext", input_file }
   for option_name, option_value in pairs(options) do
     if option_value ~= "" then
-      cmd = cmd .. option_name .. "=" .. option_value .. " "
+      local option = option_name .. "=" .. option_value
+      table.insert(cmd, option)
     else
       -- empty string value implies this options is just a flag
-      cmd = cmd .. option_name .. " "
+      table.insert(cmd, option_name)
     end
   end
 

--- a/lua/jupytext/health.lua
+++ b/lua/jupytext/health.lua
@@ -1,13 +1,12 @@
 local M = {}
 
 M.check = function()
-  vim.health.report_start "jupytext.nvim"
-  vim.fn.system "jupytext --version"
-
+  vim.health.start "jupytext.nvim"
+  vim.fn.system({ "jupytext", "--version" })
   if vim.v.shell_error == 0 then
-    vim.health.report_ok "Jupytext is available"
+    vim.health.ok "Jupytext is available"
   else
-    vim.health.report_error("Jupytext is not available", "Install jupytext via `pip install jupytext`")
+    vim.health.error("Jupytext is not available", "Install jupytext via `pip install jupytext`")
   end
 end
 

--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -16,11 +16,13 @@ local write_to_ipynb = function(event, output_extension)
   jupytext_filename = vim.fn.resolve(vim.fn.expand(jupytext_filename))
 
   vim.cmd.write({ jupytext_filename, bang = true })
-  commands.run_jupytext_command(vim.fn.shellescape(jupytext_filename), {
+
+  commands.run_jupytext_command(jupytext_filename, {
     ["--update"] = "",
     ["--to"] = "ipynb",
-    ["--output"] = vim.fn.shellescape(ipynb_filename),
+    ["--output"] = ipynb_filename,
   })
+
   local buf = vim.api.nvim_get_current_buf()
   vim.api.nvim_set_option_value("modified", false, { buf = buf })
 
@@ -68,7 +70,7 @@ end
 
 local read_from_ipynb = function(ipynb_filename)
   local metadata = utils.get_ipynb_metadata(ipynb_filename)
-  local ipynb_filename = vim.fn.resolve(vim.fn.expand(ipynb_filename))
+  ipynb_filename = vim.fn.resolve(vim.fn.expand(ipynb_filename))
 
   -- Decide output extension and style
   local custom_formatting, output_extension, to_extension_and_style = style_and_extension(metadata)
@@ -79,9 +81,9 @@ local read_from_ipynb = function(ipynb_filename)
   local filename_exists = vim.fn.filereadable(ipynb_filename)
 
   if filename_exists and not jupytext_file_exists then
-    commands.run_jupytext_command(vim.fn.shellescape(ipynb_filename), {
+    commands.run_jupytext_command(ipynb_filename, {
       ["--to"] = to_extension_and_style,
-      ["--output"] = vim.fn.shellescape(jupytext_filename),
+      ["--output"] = jupytext_filename,
     })
   end
 


### PR DESCRIPTION
@gogamid 's 2 fixes from https://github.com/GCBallesteros/jupytext.nvim/pull/25

+ removed the shellescaped commands from init.lua as @tjni suggested

Checkhealth and importing .ipynb now works on (NVIM v0.11.0-dev-1186+g1763eddede)