### PR TITLE
fix: don't use deprecated nvim_err_writeln

### DIFF
--- a/lua/jupytext/commands.lua
+++ b/lua/jupytext/commands.lua
@@ -15,7 +15,7 @@ M.run_jupytext_command = function(input_file, options)
 
   if vim.v.shell_error ~= 0 then
     print(output)
-    vim.api.nvim_err_writeln(cmd .. ": " .. vim.v.shell_error)
+    vim.api.nvim_echo(cmd .. ": " .. vim.v.shell_error, true, { err = true })
     return
   end
 end


### PR DESCRIPTION
`nvim_err_writeln()` has been deprecated: https://github.com/neovim/neovim/issues/31871

Now `nvim_echo()` has an err option to replace it