### PR TITLE
Add handling for the C++ language

### DIFF
--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -136,6 +136,10 @@ local read_from_ipynb = function(ipynb_filename)
     ft = metadata.language
   end
 
+  if ft == "c++" then
+    ft = "cpp"
+  end
+
   -- In order to make :undo a no-op immediately after the buffer is read, we
   -- need to do this dance with 'undolevels'.  Actually discarding the undo
   -- history requires performing a change after setting 'undolevels' to -1 and,

--- a/lua/jupytext/utils.lua
+++ b/lua/jupytext/utils.lua
@@ -7,6 +7,7 @@ local language_extensions = {
   R = "r",
   bash = "sh",
 }
+language_extensions["c++"] = "cpp"
 
 local language_names = {
   python3 = "python",


### PR DESCRIPTION
This pull request allows jupytext.nvim to be used with C++ notebooks such as those that use the kernel provided with the [ROOT data analysis framework](https://github.com/root-project/root/tree/master/bindings/jupyroot#c-rootbook)