### PR TITLE
fix: Update deprecated health checks for vim.health

### DIFF
--- a/lua/jupytext/health.lua
+++ b/lua/jupytext/health.lua
@@ -1,13 +1,13 @@
 local M = {}
 
 M.check = function()
-  vim.health.report_start "jupytext.nvim"
+  vim.health.start("jupytext.nvim")
   vim.fn.system "jupytext --version"
 
   if vim.v.shell_error == 0 then
-    vim.health.report_ok "Jupytext is available"
+    vim.health.ok("Jupytext is available")
   else
-    vim.health.report_error("Jupytext is not available", "Install jupytext via `pip install jupytext`")
+    vim.health.error("Jupytext is not available", "Install jupytext via `pip install jupytext`")
   end
 end
 


### PR DESCRIPTION
## Description
Update deprecated `vim.health` references so `:checkhealth jupytext` works properly.

<img width="922" alt="Screenshot 2025-05-12 at 6 18 19 PM" src="https://github.com/user-attachments/assets/bb2a4542-b4a7-42ea-ab2e-c0eef2459ea7" />

Using the following configuration through nixvim:
~~~
    jupytext = {
      enable = true;
      package = pkgs.vimUtils.buildVimPlugin {
        pname = "jupytext.nvim";
        src = pkgs.fetchgit {
          url = "https://github.com/bkp5190/jupytext.nvim";
          branchName = "deprecated-healthcheck";
          rev = "695295069a3aac0cf9a1b768589216c5b837b6f1";
          sha256 = "sha256-W6fkL1w2dYSjpAYOtBTlYjd2CMYPB596NQzBylIVHrE=";
        };
      };
    };
~~~