### PR TITLE
fix: failures to detect language and file extensions

### DIFF
--- a/lua/jupytext/init.lua
+++ b/lua/jupytext/init.lua
@@ -49,7 +49,7 @@ local style_and_extension = function(metadata)
     else
       output_extension = M.config.output_extension
     end
-    to_extension_and_style = M.config.output_extension .. ":" .. M.config.style
+    to_extension_and_style = output_extension .. ":" .. M.config.style
   end
 
   return custom_formatting, output_extension, to_extension_and_style

--- a/lua/jupytext/utils.lua
+++ b/lua/jupytext/utils.lua
@@ -14,16 +14,36 @@ local language_names = {
 
 M.get_ipynb_metadata = function(filename)
   local metadata = vim.json.decode(io.open(filename, "r"):read "a")["metadata"]
-  local language = metadata.kernelspec.language
-  if language == nil then
-    language = language_names[metadata.kernelspec.name]
+  local language
+
+  if metadata.kernelspec then
+    language = metadata.kernelspec.language
+    if not language and metadata.kernelspec.name then
+      language = language_names[metadata.kernelspec.name]
+    end
   end
+
+  if not language and metadata.jupytext then
+    language = metadata.jupytext.main_language
+  end
+
+  if not language and metadata.language_info then
+    language = metadata.language_info.name
+  end
+
+  if not language and metadata["application/vnd.databricks.v1+notebook"] then
+    language = metadata["application/vnd.databricks.v1+notebook"].language
+  end
+
   local extension = language_extensions[language]
 
   return { language = language, extension = extension }
 end
 
 M.get_jupytext_file = function(filename, extension)
+  if extension == nil then
+    error("Could not determine a jupytext file extension for " .. filename)
+  end
   local fileroot = vim.fn.fnamemodify(filename, ":r")
   return fileroot .. "." .. extension
 end


### PR DESCRIPTION
The plugin was failing for notebooks created on Azure DataBricks, because it stored language information in unsupported metadata fields. This PR fixes this issue.